### PR TITLE
remove unsafe

### DIFF
--- a/netlink-packet-wireguard/Cargo.toml
+++ b/netlink-packet-wireguard/Cargo.toml
@@ -14,6 +14,7 @@ description = "Wireguard generic netlink packet definitions"
 anyhow = "1.0.42"
 byteorder = "1.4.3"
 libc = "0.2.98"
+log = "0.4.14"
 netlink-packet-generic = "0.1.0"
 netlink-packet-utils = "0.4.1"
 

--- a/netlink-packet-wireguard/examples/get_wireguard_info.rs
+++ b/netlink-packet-wireguard/examples/get_wireguard_info.rs
@@ -87,8 +87,8 @@ fn print_wg_peer(nlas: &[WgPeerAttrs]) {
 
 fn print_wg_allowedip(nlas: &[WgAllowedIpAttrs]) -> Option<()> {
     let ipaddr = nlas.iter().find_map(|nla| {
-        if let WgAllowedIpAttrs::IpAddr(ipaddr) = nla {
-            Some(*ipaddr)
+        if let WgAllowedIpAttrs::IpAddr(addr) = nla {
+            Some(*addr)
         } else {
             None
         }

--- a/netlink-packet-wireguard/src/constants.rs
+++ b/netlink-packet-wireguard/src/constants.rs
@@ -1,3 +1,6 @@
+pub const AF_INET: u16 = libc::AF_INET as u16;
+pub const AF_INET6: u16 = libc::AF_INET6 as u16;
+
 pub const WG_KEY_LEN: usize = 32;
 
 pub const WG_CMD_GET_DEVICE: u8 = 0;

--- a/netlink-packet-wireguard/src/lib.rs
+++ b/netlink-packet-wireguard/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate log;
+
 use crate::constants::*;
 use anyhow::Context;
 use netlink_packet_generic::{GenlFamily, GenlHeader};


### PR DESCRIPTION
First, `miri` didn't like this unsafe:

```
running 3 tests
test raw::test::test_parse_sockaddr_in6_1 ... ok
test raw::test::test_parse_sockaddr_in_1 ... error: Undefined Behavior: accessing memory with alignment 1, but alignment 2 is required
   --> netlink-packet-wireguard/src/raw.rs:136:32
    |
136 |     let data: &'a T = unsafe { &*ptr };
    |                                ^^^^^ accessing memory with alignment 1, but alignment 2 is required
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

    = note: inside `raw::from_raw_slice::<libc::sockaddr>` at netlink-packet-wireguard/src/raw.rs:136:32
note: inside `raw::parse_sockaddr` at netlink-packet-wireguard/src/raw.rs:91:41
   --> netlink-packet-wireguard/src/raw.rs:91:41
    |
91  |     let csockaddr: &sockaddr = unsafe { from_raw_slice(buf)? };
    |                                         ^^^^^^^^^^^^^^^^^^^
note: inside `raw::test::test_parse_sockaddr_in_1` at netlink-packet-wireguard/src/raw.rs:160:22
   --> netlink-packet-wireguard/src/raw.rs:160:22
    |
160 |         let ipaddr = parse_sockaddr(&SOCKADDR_IN_BYTES_1).unwrap();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure at netlink-packet-wireguard/src/raw.rs:159:5
   --> netlink-packet-wireguard/src/raw.rs:159:5
    |
158 |       #[test]
    |       ------- in this procedural macro expansion
159 | /     fn test_parse_sockaddr_in_1() {
160 | |         let ipaddr = parse_sockaddr(&SOCKADDR_IN_BYTES_1).unwrap();
161 | |         assert_eq!(ipaddr, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 7290).into());
162 | |     }
    | |_____^
```

Second, although in C the netlink packets are encoded en decoded by
simply transmuting slices into struct, we cannot safely to this in
Rust unless the types are _at least_ `#[repr(C)]`. If we want to go
down that path, I think we have two choices:

- using bindgen to wrap the C structs, and use the same strategy than
in C
- defining `#[repr(C)]` structs and use something like `bytemuck` to
  convert slices into structs and vice-versa.

The other netlink crates took the third option of going full rust and
manually parsing the packets. For consistency, this commit implements
this solution.